### PR TITLE
Extract text from html

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,36 +6,53 @@ from concurrent import futures
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from google.cloud import language_v1
+from lxml import html
 
 app = Flask(__name__)
-CORS(app, resources={r"/classify": {"origins": "chrome-extension://*"}})
+CORS(app, resources={r"/classify": {"origins": "chrome-extension://eidcnjleeocfiinfohngojmekjeaknej"}})
 
 # Set up for Cloud Natural Language API
-client = language_v1.LanguageServiceClient()
-type_ = language_v1.Document.Type.HTML
-content_categories_version = (
+TYPE = language_v1.Document.Type.PLAIN_TEXT
+CONTENT_CATEGORY_VERSION = (
     language_v1.ClassificationModelOptions.V2Model.ContentCategoriesVersion.V2
 )
+client = language_v1.LanguageServiceClient()
+
+# Find text in the following xpath tags
+XPATH_TAGS = './/title|.//h1|.//h2|.//h3|.//h4|.//h5|.//h6|.//p'
+
+def extract_text_from_url(url: str):
+    try:
+        html_text = requests.get(url).text
+        root = html.fromstring(html_text)
+        text_list = map(lambda tag: tag.text_content(), root.xpath(XPATH_TAGS))
+        return ' '.join(text_list)
+    except:
+        # Accept only http(s) scheme
+        raise Exception("Invalid scheme or content")
 
 def classify_single_url(url: str):
     try:
+        # Clip letters to keep bills down
+        text = extract_text_from_url(url)[:990]
         document = {
-            "content": requests.get(url).text,
-            "type_": type_,
+            "content": text,
+            "type_": TYPE,
         }
         response = client.classify_text(
             request={
                 "document": document,
                 "classification_model_options": {
-                    "v2_model": {"content_categories_version": content_categories_version}
+                    "v2_model": {"content_categories_version": CONTENT_CATEGORY_VERSION}
                 },
             }
         )
-        # category must be something like `/first(/second(/third))`
+        # `category` must be something like `/first(/second(/third))`
         category = response.categories[0].name
         category = category.split('/')[1]
     except:
         category = 'Unclassified'
+
     return (f"{category}", f"{url}")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask==2.3.3
 Flask-Cors==4.0.0
 gunicorn==20.1.0
 google-cloud-language==2.11.0
+lxml==4.9.3


### PR DESCRIPTION
各URLについてHTML全文をNatural Language APIに送ってしまっていたので、HTML内のp, hx, titleタグ内のテキスト(の最初の990字)を抽出して送る仕様にしました